### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 The Model Context Protocol (MCP) is an open standard that enables AI systems to interact seamlessly with various data sources and tools, facilitating secure, two-way connections.
 
+<a href="https://glama.ai/mcp/servers/@Cognitive-Stack/search-stock-news-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cognitive-Stack/search-stock-news-mcp/badge" alt="Search Stock News Server MCP server" />
+</a>
+
 The Search Stock News MCP server provides:
 
 * Real-time stock news search capabilities via Tavily API
@@ -184,4 +188,4 @@ Add the server configuration:
 
 ## License
 
-MIT 
+MIT


### PR DESCRIPTION
This PR adds a badge for the [Search Stock News MCP Server](https://glama.ai/mcp/servers/@Cognitive-Stack/search-stock-news-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Cognitive-Stack/search-stock-news-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Cognitive-Stack/search-stock-news-mcp/badge" alt="Search Stock News Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.